### PR TITLE
fix fem notebook

### DIFF
--- a/notebooks/20_modesolver_fem.ipynb
+++ b/notebooks/20_modesolver_fem.ipynb
@@ -45,7 +45,6 @@
     "from tqdm.auto import tqdm\n",
     "import numpy as np\n",
     "\n",
-    "from gplugins.femwell.mode_solver import compute_cross_section_modes\n",
     "from gdsfactory.technology import LayerStack\n",
     "from gdsfactory.cross_section import rib\n",
     "from gdsfactory.generic_tech import LAYER_STACK\n",
@@ -53,7 +52,6 @@
     "from skfem.io.meshio import from_meshio\n",
     "\n",
     "from femwell.maxwell.waveguide import compute_modes\n",
-    "from femwell.mesh import mesh_from_OrderedDict\n",
     "from femwell.visualization import plot_domains\n",
     "\n",
     "import sys\n",
@@ -62,6 +60,23 @@
     "import gdsfactory as gf\n",
     "from gdsfactory.generic_tech import get_generic_pdk\n",
     "\n",
+    "from gplugins.gmsh import get_mesh\n",
+    "\n",
+    "from collections import OrderedDict\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "import shapely\n",
+    "import shapely.affinity\n",
+    "from scipy.constants import epsilon_0, speed_of_light\n",
+    "from shapely.ops import clip_by_rect\n",
+    "from skfem import Basis, ElementTriP0\n",
+    "from skfem.io.meshio import from_meshio\n",
+    "\n",
+    "from femwell.maxwell.waveguide import compute_modes\n",
+    "from femwell.mesh import mesh_from_OrderedDict\n",
+    "from femwell.visualization import plot_domains\n",
+    "\n",
     "gf.config.rich_output()\n",
     "PDK = get_generic_pdk()\n",
     "PDK.activate()\n",
@@ -69,6 +84,35 @@
     "logger = logging.getLogger()\n",
     "logger.removeHandler(sys.stderr)\n",
     "logging.basicConfig(level=\"WARNING\", datefmt=\"[%X]\", handlers=[RichHandler()])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fe127568",
+   "metadata": {},
+   "source": [
+    "First we choose a component to simulate. Here, a straight strip waveguide:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ade309cf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xs = gf.cross_section.strip(width=1)\n",
+    "\n",
+    "c = gf.components.straight(cross_section=xs)\n",
+    "c"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e7d7e535",
+   "metadata": {},
+   "source": [
+    "Then we choose a Layer Stack. Here, we simply downsample the generic stack:"
    ]
   },
   {
@@ -88,22 +132,15 @@
     "            \"box\",\n",
     "        )\n",
     "    }\n",
-    ")\n",
-    "\n",
-    "filtered_layer_stack.layers[\n",
-    "    \"core\"\n",
-    "].thickness = 0.22  # Perturb the layer_stack before simulating\n",
-    "\n",
-    "filtered_layer_stack.layers[\n",
-    "    \"slab90\"\n",
-    "].thickness = 0.09  # Perturb the layer_stack before simulating\n",
-    "\n",
-    "resolutions = {\n",
-    "    \"core\": {\"resolution\": 0.02, \"distance\": 2},\n",
-    "    \"clad\": {\"resolution\": 0.2, \"distance\": 1},\n",
-    "    \"box\": {\"resolution\": 0.2, \"distance\": 1},\n",
-    "    \"slab90\": {\"resolution\": 0.05, \"distance\": 1},\n",
-    "}"
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "02bf38b3",
+   "metadata": {},
+   "source": [
+    "We can also change some of the values:"
    ]
   },
   {
@@ -113,13 +150,67 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "modes = compute_cross_section_modes(\n",
-    "    cross_section=rib(width=0.6),\n",
-    "    layer_stack=filtered_layer_stack,\n",
-    "    wavelength=1.55,\n",
-    "    num_modes=4,\n",
-    "    resolutions=resolutions,\n",
-    ")"
+    "filtered_layer_stack.layers[\n",
+    "    \"core\"\n",
+    "].thickness = 0.22  # Perturb the layer_stack before simulating\n",
+    "\n",
+    "filtered_layer_stack.layers[\n",
+    "    \"slab90\"\n",
+    "].thickness = 0.09  # Perturb the layer_stack before simulating\n",
+    "\n",
+    "# When selecting resolutions, the names must match the keys of the layerstack\n",
+    "# Here, choose a finer mesh inside and close to the core\n",
+    "resolutions = {\n",
+    "    \"core\": {\"resolution\": 0.02, \"DistMax\": 2, \"SizeMax\": 0.2},\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "27e0a338",
+   "metadata": {},
+   "source": [
+    "Using gplugins, we quickly generate a cross-sectional mesh:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "56532903",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mesh_gmsh = get_mesh(component=c,\n",
+    "                layer_stack=filtered_layer_stack,\n",
+    "                type=\"uz\", # we want a cross-section\n",
+    "                xsection_bounds=((1, -3),(1, 3)), # the line from which we take a cross-section\n",
+    "                wafer_padding=3, # pad simulation domain 3 microns around the component\n",
+    "                filename=\"mesh.msh\",\n",
+    "                resolutions=resolutions,\n",
+    "                default_characteristic_length=0.5,\n",
+    "                )\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "adc8f3e7",
+   "metadata": {},
+   "source": [
+    "We can now throw this mesh into FEMWELL directly:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fceeda94",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mesh = from_meshio(mesh_gmsh)\n",
+    "mesh.draw().show()\n",
+    "\n",
+    "plot_domains(mesh)\n",
+    "plt.show()"
    ]
   },
   {
@@ -127,7 +218,7 @@
    "id": "77219d23",
    "metadata": {},
    "source": [
-    "The solver returns the list of modes"
+    "Assign material values"
    ]
   },
   {
@@ -139,8 +230,31 @@
    },
    "outputs": [],
    "source": [
-    "mode = modes[0]\n",
-    "mode.show(mode.E.real, colorbar=True, direction=\"x\")"
+    "basis0 = Basis(mesh, ElementTriP0())\n",
+    "epsilon = basis0.zeros()\n",
+    "for subdomain, n in {\"core\": 3.45, \"box\": 1.444, \"clad\": 1.444}.items():\n",
+    "    epsilon[basis0.get_dofs(elements=subdomain)] = n**2\n",
+    "basis0.plot(epsilon, colorbar=True).show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "426fec76",
+   "metadata": {},
+   "source": [
+    "Solve for the modes:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9d4c90f9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "wavelength = 1.55\n",
+    "\n",
+    "modes = compute_modes(basis0, epsilon, wavelength=wavelength, num_modes=2, order=2)"
    ]
   },
   {
@@ -162,57 +276,23 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "19d73e30",
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "64b48ade",
    "metadata": {},
+   "outputs": [],
    "source": [
-    "## Sweep waveguide width"
+    "modes[0].show(\"E\", part=\"real\")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ec25ad88",
-   "metadata": {
-    "lines_to_next_cell": 2
-   },
-   "outputs": [],
-   "source": [
-    "widths = np.linspace(0.2, 2, 10)\n",
-    "num_modes = 4\n",
-    "all_neffs = np.zeros((widths.shape[0], num_modes))\n",
-    "all_te_fracs = np.zeros((widths.shape[0], num_modes))\n",
-    "\n",
-    "\n",
-    "for i, width in enumerate(tqdm(widths)):\n",
-    "    modes = compute_cross_section_modes(\n",
-    "        cross_section=gf.cross_section.strip(width=width),\n",
-    "        layer_stack=filtered_layer_stack,\n",
-    "        wavelength=1.55,\n",
-    "        num_modes=num_modes,\n",
-    "        resolutions=resolutions,\n",
-    "        wafer_padding=2,\n",
-    "        solver=\"scipy\",\n",
-    "    )\n",
-    "    all_neffs[i] = np.real([mode.n_eff for mode in modes])\n",
-    "    all_te_fracs[i, :] = [mode.te_fraction for mode in modes]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "c430b3ed",
+   "id": "e07fb506",
    "metadata": {},
    "outputs": [],
    "source": [
-    "all_neffs = np.real(all_neffs)\n",
-    "plt.xlabel(\"Width of waveguide  µm\")\n",
-    "plt.ylabel(\"Effective refractive index\")\n",
-    "plt.ylim(1.444, np.max(all_neffs) + 0.1 * (np.max(all_neffs) - 1.444))\n",
-    "for lams, te_fracs in zip(all_neffs.T, all_te_fracs.T):\n",
-    "    plt.plot(widths, lams, c='k')\n",
-    "    plt.scatter(widths, lams, c=te_fracs, cmap=\"cool\")\n",
-    "plt.colorbar().set_label(\"TE fraction\")"
+    "modes[1].show(\"E\", part=\"real\")"
    ]
   }
  ],
@@ -238,7 +318,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.4"
+   "version": "3.11.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
quick fix to the femwell notebook. Need to make sure femwell 0.1.11 is the version being used

The femwell plugin is obsoleted, since both gdsfactory and femwell have changed too much

This notebook simply uses the meshing plugin (which is up to date), and throws the generated mesh into a manual femwell calculation. This is what the plugin used to do under the hood, and what we always do in practice anyway

@joamatab @HelgeGehring