### PR TITLE
latest gdsfactory

### DIFF
--- a/notebooks/10_layout_full.ipynb
+++ b/notebooks/10_layout_full.ipynb
@@ -72,13 +72,11 @@
     "r = c << r  # Add the rectangle we created\n",
     "\n",
     "# Now that the geometry has been added to \"c\", we can move everything around:\n",
-    "text1.dmovey(25)\n",
-    "text2.dmove([5, 30])\n",
-    "text2.drotate(45)\n",
-    "r.dmovex(-15)\n",
-    "\n",
-    "print(c)\n",
-    "c.plot()"
+    "text1.movey(25)\n",
+    "text2.move([5, 30])\n",
+    "text2.rotate(45)\n",
+    "r.movex(-15)\n",
+    "c"
    ]
   },
   {
@@ -183,11 +181,11 @@
     "wg1 = c << straight(length=6, width=2.5, layer=(1, 0))\n",
     "wg2 = c << straight(length=6, width=2.5, layer=(2, 0))\n",
     "wg3 = c << straight(length=15, width=2.5, layer=(3, 0))\n",
-    "wg2.dmovey(10)\n",
-    "wg2.drotate(10)\n",
+    "wg2.movey(10)\n",
+    "wg2.rotate(10)\n",
     "\n",
-    "wg3.dmovey(20)\n",
-    "wg3.drotate(15)\n",
+    "wg3.movey(20)\n",
+    "wg3.rotate(15)\n",
     "\n",
     "c.plot()"
    ]
@@ -199,7 +197,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "wg2.dmovex(10)"
+    "wg2.movex(10)"
    ]
   },
   {
@@ -309,10 +307,10 @@
     "wg3 = c << straight(length=3, layer=(3, 0))\n",
     "\n",
     "# Shift the second straight we created over by dx = 2, dy = 2 um. D stands for Decimal\n",
-    "wg2.dmove([2.0, 2.0])\n",
+    "wg2.move([2.0, 2.0])\n",
     "\n",
     "# Then, move again the third straight by 3um\n",
-    "wg3.dmovex(3)  # equivalent to wg3.dmove(3)\n",
+    "wg3.movex(3)  # equivalent to wg3.dmove(3)\n",
     "\n",
     "c.plot()"
    ]
@@ -338,11 +336,11 @@
     "wg2 = c << straight(length=2, layer=(2, 0))\n",
     "wg3 = c << straight(length=3, layer=(3, 0))\n",
     "\n",
-    "# Shift the second straight we created over so that the xmin matches wg1.dxmax\n",
-    "wg2.dxmin = wg1.dxmax\n",
+    "# Shift the second straight we created over so that the xmin matches wg1.xmax\n",
+    "wg2.xmin = wg1.xmax\n",
     "\n",
     "# Then, leave a 1um gap with on the last straight\n",
-    "wg3.dxmin = wg2.dxmax + 1\n",
+    "wg3.xmin = wg2.xmax + 1\n",
     "\n",
     "c.plot()"
    ]
@@ -730,7 +728,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.11.8"
   }
  },
  "nbformat": 4,

--- a/notebooks/30_mzi.ipynb
+++ b/notebooks/30_mzi.ipynb
@@ -432,7 +432,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.11.8"
   }
  },
  "nbformat": 4,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
   "Operating System :: OS Independent"
 ]
 dependencies = [
-  "gdsfactory==8.20.0",
+  "gdsfactory==8.23.0",
   "gplugins[tidy3d,sax,schematic,femwell]"
 ]
 description = "pic_training"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,9 @@ classifiers = [
   "Operating System :: OS Independent"
 ]
 dependencies = [
-  "gdsfactory==8.23.0",
-  "gplugins[tidy3d,sax,schematic,femwell]"
+  "gdsfactory~=8.23.0",
+  "gplugins[tidy3d,sax,schematic,femwell]",
+  "numpy<2",
 ]
 description = "pic_training"
 keywords = ["python"]


### PR DESCRIPTION
## Summary by Sourcery

Update gdsfactory to version 8.23.0 and refactor notebooks to replace deprecated movement and rotation methods with their updated counterparts.

Enhancements:
- Update gdsfactory dependency from version 8.20.0 to 8.23.0 in pyproject.toml.

Chores:
- Replace deprecated 'dmove', 'dmovex', 'dmovey', 'drotate' methods with 'move', 'movex', 'movey', 'rotate' in notebooks for consistency with updated gdsfactory API.