### PR TITLE
fix: remove polyfill.io, fix notebook build, bump CI actions

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -16,8 +16,8 @@ jobs:
     steps:
       - name: Cancel Workflow Action
         uses: styfle/cancel-workflow-action@0.13.1
-      - uses: actions/checkout@v6
-      - uses: actions/cache@v4
+      - uses: actions/checkout@v7
+      - uses: actions/cache@v6
         with:
           path: |
             ~/.gdsfactory/

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ git-rm-merged:
 
 nbdocs:
 	@echo "Converting notebooks to markdown..."
-	@find docs -name "*.ipynb" | xargs -P4 -I{} sh -c '\
+	@find -L docs -name "*.ipynb" | xargs -P4 -I{} sh -c '\
 		echo "  [exec] {}"; \
 		jupyter nbconvert --to markdown --execute --embed-images \
 			--ExecutePreprocessor.allow_errors=True \

--- a/docs/zensical.yml
+++ b/docs/zensical.yml
@@ -62,5 +62,4 @@ markdown_extensions:
       alternate_style: true
 
 extra_javascript:
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js


### PR DESCRIPTION
## Summary

- **Remove polyfill.io script** from `docs/zensical.yml` —  MathJax 3 handles its own polyfills, so this script was unnecessary.
- **Fix notebook conversion** in `Makefile` — `find docs` was not following the `docs/notebooks` symlink, so no notebooks were converted to markdown. The zensical build succeeded silently with no content pages. Added `-L` flag to `find`.
- **Bump `actions/checkout` v6→v7 and `actions/cache` v4→v6** (combines dependabot PRs #81 and #82).

Closes #87

## Test plan

- [ ] Verify the deployed site no longer shows a polyfill login prompt
- [ ] Verify all notebook pages render (e.g. `/notebooks/10_layout_full/`)
- [ ] Verify CI passes with the bumped actions

## Summary by Sourcery

Remove a compromised polyfill script, fix notebook conversion in the docs build, and update CI GitHub Actions versions.

Bug Fixes:
- Ensure notebook files in the docs/notebooks symlink are discovered and converted to markdown during the docs build.

Enhancements:
- Stop loading the external polyfill.io JavaScript in the documentation site configuration, relying on MathJax’s own polyfill handling instead.

CI:
- Bump actions/checkout from v6 to v7 and actions/cache from v4 to v6 in the Pages workflow.