### PR TITLE
fix: fail docs build on notebook execution errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,9 +20,8 @@ nbdocs:
 		xargs -P4 -I{} sh -c '\
 		echo "  [exec] {}"; \
 		jupyter nbconvert --to markdown --execute --embed-images \
-			--ExecutePreprocessor.allow_errors=True \
 			--ExecutePreprocessor.timeout=600 "{}" \
-			--output-dir docs/notebooks 2>/dev/null || true'
+			--output-dir docs/notebooks'
 	python docs/hooks.py docs/notebooks/*.md
 
 docs: nbdocs


### PR DESCRIPTION
## Summary

- Remove `--ExecutePreprocessor.allow_errors=True` so notebook execution errors are not silently swallowed
- Remove `2>/dev/null` and `|| true` so failures propagate to CI

Currently `30_mzi` and `31_ring` have real execution errors that render as visible tracebacks on the deployed site, but CI never catches them. After this change, the docs build will fail until those notebooks are fixed.

Closes #90

## Test plan

- [ ] CI should **fail** on this PR (expected — `30_mzi` and `31_ring` have errors that need fixing)
- [ ] Once notebooks are fixed, CI passes and deployed docs are error-free

## Summary by Sourcery

Fail documentation notebook build when execution errors occur, ensuring CI surfaces notebook failures.

Build:
- Update nbdocs Makefile target to treat jupyter nbconvert notebook execution errors as build failures by removing error-swallowing flags.

CI:
- Allow notebook execution failures in docs generation to cause CI failures instead of being ignored.