### PR TITLE
use tqdm.auto in heater FEM notebook

### DIFF
--- a/notebooks/22_heater_fem.ipynb
+++ b/notebooks/22_heater_fem.ipynb
@@ -71,7 +71,7 @@
     "from femwell.thermal import solve_thermal\n",
     "from shapely.geometry import LineString, Polygon\n",
     "from skfem import Basis, ElementTriP0\n",
-    "from tqdm import tqdm"
+    "from tqdm.auto import tqdm"
    ]
   },
   {


### PR DESCRIPTION
Fixes #101

`notebooks/22_heater_fem.ipynb` imported `from tqdm import tqdm`, which forces the CLI progress bar and renders as garbled carriage-return output in the built docs. `tqdm.auto` picks the notebook frontend under Jupyter and falls back to the CLI bar elsewhere.

One-line change; `pre-commit` passes clean on the touched file.

Requested by @joamatab

## Summary by Sourcery

Bug Fixes:
- Use the appropriate notebook or terminal progress-bar frontend in the heater FEM notebook to prevent garbled progress output in built documentation.